### PR TITLE
Legge til autofyll i tekstfeltet

### DIFF
--- a/src/AutocompleteListItem.svelte
+++ b/src/AutocompleteListItem.svelte
@@ -1,0 +1,42 @@
+<script>
+  export let itemLabel;
+  export let highlighted;
+  export let capitalized = false;
+  export let handleHover = null;
+  export let handleClick = null;
+</script>
+
+<li
+  class="autocomplete-items"
+  class:capitalized
+  class:autocomplete-active={highlighted}
+  on:mouseenter={() => handleHover(itemLabel)}
+  on:click={() => handleClick(itemLabel)}
+>
+  {@html itemLabel}
+</li>
+
+<style>
+  li.autocomplete-items {
+    list-style: none;
+    z-index: 99;
+    top: 100%;
+    left: 0;
+    right: 0;
+    padding: 0.5em;
+    margin: 0 0.5em;
+    cursor: pointer;
+    background-color: #fff;
+  }
+
+  .capitalized {
+    text-transform: capitalize;
+  }
+
+  .autocomplete-active {
+    /* when navigating through the items using the arrow keys and hovering */
+    background-color: #eee !important;
+    color: #333;
+    border-radius: 0.5em;
+  }
+</style>

--- a/src/Main.svelte
+++ b/src/Main.svelte
@@ -99,8 +99,10 @@
       (element) => !commands.includes(element)
     );
 
-    typeahead = filteredList.at(0).replace(inputValue.toLowerCase(), "");
-    selectedIndex = 0;
+    if (filteredList.length > 0) {
+      selectedIndex = 0;
+      typeahead = filteredList.at(0).replace(inputValue.toLowerCase(), "");
+    }
   };
 
   const handleSubmit = () => {


### PR DESCRIPTION
Inspirert av paletten til GitHub har jeg lagt til autofyll til tekstfeltet.

Endringer:
- n og s som kommandoer er erstattet av autofyll
- når man trykker inn i tekstfeltet får man opp alle kommandoene
- begynner man å skrive vil eksisterende navn autofylles
- man kan trykke tab for å fylle uten å gjøre handlingen
- man kan føre musen over et listeelement og trykke tab for å fylle et listeelement lengre ned
- mulig å klikke på et av forslagene for å gjøre handlingen
- jeg har skrevet om måten input håndteres på for å ta hensyn til autofyll-funksjonen
- siden inputValue nå er reaktiv, fjernet jeg HTML-elementet `input` som parameter fra en del funksjoner

![bilde](https://user-images.githubusercontent.com/36609741/213825059-fdfe0216-35c0-4a1a-9641-101e1a1aba4a.png)
